### PR TITLE
送信関係の修正

### DIFF
--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -96,7 +96,9 @@ export default class extends Component {
         inp.current.value = ""
       }
     }
-    const [isOpenMenu, setIsOpenMenu] = useState(false)
+    const [isOpenMenu, setIsOpenMenu] = useState(false)  // メニューがオンか
+    const [canSubmit, setCanSubmit] = useState(false) // 送信可能か
+
     return (
       <>
         <div class="relative w-full h-full">
@@ -113,6 +115,9 @@ export default class extends Component {
                   sendMessage()
                 }
               }}
+              onInput={(e)=>{
+                setCanSubmit(e.target.value !== "")
+              }}
               class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
             />
             <button
@@ -120,7 +125,7 @@ export default class extends Component {
                 sendMessage()
               }}
               class="mx-5 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center"
-              disabled={inp.current?.value === ""}
+              disabled={!canSubmit}
             >
               <IconSend />
             </button>

--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -79,7 +79,23 @@ export default class extends Component {
         inp.current.value += " >>" + msg + " ";
       }
     }
-
+    const sendMessage = (): void => {
+      if (inp.current?.value === "") {
+        alert(
+          "送信できませんでした。 送信内容が空の可能性が有ります。"
+        );
+        return;
+      }
+      this.state.socket.emit("message", {
+        body: inp.current?.value,
+        room: this.byProps.roomId,
+        uuid: crypto.randomUUID(),
+      })
+      if (inp.current) {
+        // 文字の消去
+        inp.current.value = ""
+      }
+    }
     const [isOpenMenu, setIsOpenMenu] = useState(false)
     return (
       <>
@@ -92,27 +108,16 @@ export default class extends Component {
               ref={inp}
               placeholder="message"
               onKeyDown={(e)=>{
-                alert(e.key)
+                if(e.key.toLowerCase() === "enter"){
+                  // Enter
+                  sendMessage()
+                }
               }}
               class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
             />
             <button
               onClick={() => {
-                if (inp.current?.value === "") {
-                  alert(
-                    "送信できませんでした。 送信内容が空の可能性が有ります。"
-                  );
-                  return;
-                }
-                this.state.socket.emit("message", {
-                  body: inp.current?.value,
-                  room: this.byProps.roomId,
-                  uuid: crypto.randomUUID(),
-                })
-                if (inp.current) {
-                  // 文字の消去
-                  inp.current.value = ""
-                }
+                sendMessage()
               }}
               class="mx-5 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center"
             >

--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -120,6 +120,7 @@ export default class extends Component {
                 sendMessage()
               }}
               class="mx-5 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center"
+              disabled={inp.current?.value === ""}
             >
               <IconSend />
             </button>

--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -91,6 +91,9 @@ export default class extends Component {
             <input
               ref={inp}
               placeholder="message"
+              onKeyDown={(e)=>{
+                alert(0)
+              }}
               class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
             />
             <button

--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -92,7 +92,7 @@ export default class extends Component {
               ref={inp}
               placeholder="message"
               onKeyDown={(e)=>{
-                alert(0)
+                alert(e.key)
               }}
               class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
             />

--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -81,11 +81,8 @@ export default class extends Component {
     }
     const [canSubmit, setCanSubmit] = useState(false) // 送信可能か
     const sendMessage = (): void => {
-      if (inp.current?.value === "") {
-        alert(
-          "送信できませんでした。 送信内容が空の可能性が有ります。"
-        );
-        return;
+      if(!(inp.current?.value)){
+        return
       }
       this.state.socket.emit("message", {
         body: inp.current?.value,

--- a/islands/Room.tsx
+++ b/islands/Room.tsx
@@ -79,6 +79,7 @@ export default class extends Component {
         inp.current.value += " >>" + msg + " ";
       }
     }
+    const [canSubmit, setCanSubmit] = useState(false) // 送信可能か
     const sendMessage = (): void => {
       if (inp.current?.value === "") {
         alert(
@@ -95,9 +96,9 @@ export default class extends Component {
         // 文字の消去
         inp.current.value = ""
       }
+      setCanSubmit(false)
     }
     const [isOpenMenu, setIsOpenMenu] = useState(false)  // メニューがオンか
-    const [canSubmit, setCanSubmit] = useState(false) // 送信可能か
 
     return (
       <>
@@ -126,6 +127,9 @@ export default class extends Component {
               }}
               class="mx-5 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded inline-flex items-center"
               disabled={!canSubmit}
+              style={{
+                opacity: canSubmit ? 1 : 0.5
+              }}
             >
               <IconSend />
             </button>


### PR DESCRIPTION
- メッセージが空の時に表示されるalertの代わりに、視覚的に送信できるできないを判断できるように
- エンターキーで送信可能に